### PR TITLE
Upgrade github actions

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -18,10 +18,10 @@ jobs:
   crawl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -29,7 +29,7 @@ jobs:
         run: pip install --user pipenv
 
       - name: Cache Python dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
         python-version: [3.9]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -29,7 +31,7 @@ jobs:
         run: pip install --user pipenv
 
       - name: Cache Python dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pip-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,10 +24,10 @@ jobs:
   crawl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -35,7 +35,7 @@ jobs:
         run: pip install --user pipenv
 
       - name: Cache Python dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}

--- a/city_scrapers/mixins/mc.py
+++ b/city_scrapers/mixins/mc.py
@@ -66,7 +66,6 @@ class MCMixin(CityScrapersSpider, metaclass=MCMixinMeta):
         """
         Parse a list of meetings from the response.
         """
-        print("donkey", response)
         items = response.json()
         if not items or len(items) == 0 or "value" not in items:
             self.logger.warning("No meetings found")


### PR DESCRIPTION
## What's this PR do?
Upgrades helper actions in our Github workflows to the latest versions: checkout (v4), setup-python (v5) and cache actions (v4).

## Why are we doing this?
This attempts to fix a mysterious dependency bug in our Github workflows in this and three other city-scraper repos (all of them recently created for our new site partners).

Although deps were building just fine for a while, something funky seems to have happened with our Github task runner environment or our cache or the sub-dependencies, causing `pipenv` installation to fail. There is no obvious cause/effect from any recent PR. Here's the stack trace:

```
Run pipenv sync
Installing dependencies from Pipfile.lock (f5f[21](https://github.com/City-Bureau/city-scrapers-new-brunswick/actions/runs/8518176952/job/23329886172#step:6:22)a)...
Traceback (most recent call last):
  File "/home/runner/.local/bin/pipenv", line 8, in <module>
    sys.exit(cli())
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/vendor/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/cli/options.py", line 58, in main
    return super().main(*args, **kwargs, windows_expand_args=False)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/vendor/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/vendor/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/vendor/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/vendor/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/vendor/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/vendor/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/vendor/click/decorators.py", line [33](https://github.com/City-Bureau/city-scrapers-new-brunswick/actions/runs/8518176952/job/23329886172#step:6:34), in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/cli/command.py", line 644, in sync
    retcode = do_sync(
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/routines/install.py", line 339, in do_sync
    do_init(
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/routines/install.py", line 680, in do_init
    do_install_dependencies(
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/routines/install.py", line 438, in do_install_dependencies
    batch_install(
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/routines/install.py", line 503, in batch_install
    deps_to_install = [
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/routines/install.py", line 506, in <listcomp>
    if not project.environment.is_satisfied(dep)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/project.py", line 512, in environment
    self._environment = self.get_environment(allow_global=allow_global)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/project.py", line 498, in get_environment
    environment = Environment(
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/environment.py", line 75, in __init__
    self._base_paths = self.get_paths()
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/environment.py", line [37](https://github.com/City-Bureau/city-scrapers-new-brunswick/actions/runs/8518176952/job/23329886172#step:6:38)5, in get_paths
    c = subprocess_run(command)
  File "/home/runner/.local/lib/python3.9/site-packages/pipenv/utils/processes.py", line 72, in subprocess_run
    return subprocess.run(
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/subprocess.py", line 1837, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/city-scrapers-new-brunswick/city-scrapers-new-brunswick/.venv/bin/python'
Error: Process completed with exit code 1.
```
Clearing the Github action cache and re-running the failed jobs fixed the issue but it's still unclear what was wrong with our cache.

I've upgraded our actions in this PR – including our caching action – in the hope this prevents dependency issues in the future. The action versions we were relying on were quite outdated and were resulting in a warning about Node deprecation, which might have been related to the dependency issue:

![image](https://github.com/City-Bureau/city-scrapers-bismarck/assets/37225902/ba84732a-a637-4bc8-bb8d-441bdd831044)

## Steps to manually test
N/A

## Are there any smells or added technical debt to note?

