### PR TITLE
🐞 Fix: Mandan source value

### DIFF
--- a/city_scrapers/mixins/mc.py
+++ b/city_scrapers/mixins/mc.py
@@ -81,7 +81,7 @@ class MCMixin(CityScrapersSpider, metaclass=MCMixinMeta):
                 time_notes="",
                 location=self._parse_location(item["eventLocation"]),
                 links=self._parse_links(item),
-                source=response.url,
+                source="https://mandannd.portal.civicclerk.com/",
             )
             meeting["status"] = self._get_status(meeting)
             meeting["id"] = self._get_id(meeting)

--- a/tests/test_bisnd_mc_cc.py
+++ b/tests/test_bisnd_mc_cc.py
@@ -56,8 +56,7 @@ def test_location():
 
 def test_source():
     assert (
-        parsed_items[0]["source"]
-        == "https://mandannd.api.civicclerk.com/v1/Events?$filter=categoryId+in+(26)+and+startDateTime+ge+2024-02-12T10:00:00Z+and+startDateTime+le+2024-09-12T10:00:00Z&$orderby=startDateTime"  # noqa
+        parsed_items[0]["source"] == "https://mandannd.portal.civicclerk.com/"  # noqa
     )
 
 


### PR DESCRIPTION
## What's this PR do?
Set the value for the source field for Mandan City feeds to the the agency's website rather than the API response.

## Why are we doing this?
To scrape Mandan, we target the city's API. We were using a link to the JSON response in our `source` field but this was confusing our partners. Instead, we've updated this to just use the agency's user-facing calendar page as the `source` value.

## Steps to manually test
<!-- Text here is not always necessary but it is generally recommended in order to aid a reviewer.
eg.
1. Ensure the project is installed:
```
pipenv sync --dev
```
2. Activate the virtual env and enter the pipenv shell:
```
pipenv shell
```
3. Run the spider:
```
scrapy crawl <spider-name> -O test_output.csv
```
4. Monitor the output and ensure no errors are raised.

5. Inspect `test_output.csv` to ensure the data looks valid.
-->

## Are there any smells or added technical debt to note?
<!-- eg. The new scraping logic includes a more complex parsing routine, which might be less efficient. Future optimization or a more robust parsing strategy may be needed if the website's layout continues to evolve. -->
